### PR TITLE
Remove class member recv send end time

### DIFF
--- a/StreamClient/ActiveSock.h
+++ b/StreamClient/ActiveSock.h
@@ -32,8 +32,6 @@ public:
 	bool Close(void); // Returns true if the close worked
 
 private:
-	CTime RecvEndTime;
-	CTime SendEndTime;
 	static WSADATA WsaData;
 	WSAEVENT write_event;
 	WSAEVENT read_event;


### PR DESCRIPTION
Removed the SendEndTime and RecvEndTime members from the class and use local const auto RecvEndTime / SendEndTime variables in the two functions RecvPartial / SendPartial and removed the if (SendEndTime / RecvEndTime == 0) checks and also removed the RecvEndTime / SendEndTime = 0 invalidations that are no longed necessary.