### PR TITLE
data type size_t supersedes int for Len information...

### DIFF
--- a/StreamServer/ISocketStream.h
+++ b/StreamServer/ISocketStream.h
@@ -4,8 +4,8 @@ class ISocketStream
 protected:
 	~ISocketStream(void) {}; // Disallow polymorphic destruction
 public:
-	virtual int Recv(void * const lpBuf, const int Len) = 0;
-	virtual int Send(const void * const lpBuf, const int Len) = 0;
+	virtual int Recv(void * const lpBuf, const size_t Len) = 0;
+	virtual int Send(const void * const lpBuf, const size_t Len) = 0;
 	virtual int GetLastError(void) = 0;
 	virtual HRESULT Disconnect(void) = 0;
 };

--- a/StreamServer/PassiveSock.cpp
+++ b/StreamServer/PassiveSock.cpp
@@ -35,7 +35,7 @@ CPassiveSock::~CPassiveSock()
 // CPassiveSock member functions
 
 // Receives up to Len bytes of data and returnds the amount received - or SOCKET_ERROR if it times out
-int CPassiveSock::Recv(void * const lpBuf, const int Len)
+int CPassiveSock::Recv(void * const lpBuf, const size_t Len)
 {
 	WSABUF buffer;
 	WSAEVENT hEvents[2] = { NULL,NULL };
@@ -102,9 +102,9 @@ int CPassiveSock::Recv(void * const lpBuf, const int Len)
 
 
 // Receives exactly Len bytes of data and returns the amount received - or SOCKET_ERROR if it times out
-int CPassiveSock::ReceiveBytes(void * const lpBuf, const int Len)
+int CPassiveSock::ReceiveBytes(void * const lpBuf, const size_t Len)
 {
-	int
+	size_t
 		bytes_received = 0,
 		total_bytes_received = 0;
 
@@ -150,7 +150,7 @@ HRESULT CPassiveSock::Disconnect(void)
 }
 
 //sends a message, or part of one
-int CPassiveSock::Send(const void * const lpBuf, const int Len)
+int CPassiveSock::Send(const void * const lpBuf, const size_t Len)
 {
 	WSABUF buffers[2];
 	WSAEVENT hEvents[2] = { NULL,NULL };
@@ -196,9 +196,9 @@ int CPassiveSock::Send(const void * const lpBuf, const int Len)
 }
 
 //sends all the data or returns a timeout
-int CPassiveSock::SendBytes(const void * const lpBuf, const int Len)
+int CPassiveSock::SendBytes(const void * const lpBuf, const size_t Len)
 {
-	int
+	size_t
 		bytes_sent = 0,
 		total_bytes_sent = 0;
 

--- a/StreamServer/PassiveSock.h
+++ b/StreamServer/PassiveSock.h
@@ -13,10 +13,10 @@ public:
 	virtual ~CPassiveSock();
 	int GetLastError() override;
 	void SetTimeoutSeconds(int NewTimeoutSeconds);
-	int Recv(void * const lpBuf, const int Len) override;
-	int Send(const void * const lpBuf, const int Len) override;
-	int ReceiveBytes(void * const lpBuf, const int nBufLen);
-	int SendBytes(const void * const lpBuf, const int Len);
+	int Recv(void * const lpBuf, const size_t Len) override;
+	int Send(const void * const lpBuf, const size_t Len) override;
+	int ReceiveBytes(void * const lpBuf, const size_t nBufLen);
+	int SendBytes(const void * const lpBuf, const size_t Len);
 	BOOL ShutDown(int nHow = SD_SEND);
 	HRESULT Disconnect(void) override;
 

--- a/StreamServer/SSLServer.cpp
+++ b/StreamServer/SSLServer.cpp
@@ -44,7 +44,7 @@ ISocketStream * CSSLServer::getSocketStream(void)
 }
 
 // Set up the connection, including SSL handshake, certificate selection/validation
-HRESULT CSSLServer::Initialize(const void * const lpBuf, const int Len)
+HRESULT CSSLServer::Initialize(const void * const lpBuf, const size_t Len)
 {
 	HRESULT hr = S_OK;
 	SECURITY_STATUS scRet;
@@ -114,7 +114,7 @@ int CSSLServer::GetLastError(void)
 		return m_SocketStream->GetLastError();
 }
 
-int CSSLServer::Recv(void* const lpBuf, const int Len)
+int CSSLServer::Recv(void* const lpBuf, const size_t Len)
 {
 	if (m_encrypting)
 		return RecvEncrypted(lpBuf, Len);
@@ -164,7 +164,7 @@ int CSSLServer::Recv(void* const lpBuf, const int Len)
 }
 
 // Receive an encrypted message, decrypt it, and return the resulting plaintext
-int CSSLServer::RecvEncrypted(void * const lpBuf, const int Len)
+int CSSLServer::RecvEncrypted(void * const lpBuf, const size_t Len)
 {
 	INT err;
 	INT i;
@@ -341,7 +341,7 @@ int CSSLServer::RecvEncrypted(void * const lpBuf, const int Len)
 
 // Send an encrypted message containing an encrypted version of 
 // whatever plaintext data the caller provides
-int CSSLServer::Send(const void * const lpBuf, const int Len)
+int CSSLServer::Send(const void * const lpBuf, const size_t Len)
 {
 	if (!lpBuf || Len > MaxMsgSize)
 		return SOCKET_ERROR;

--- a/StreamServer/SSLServer.h
+++ b/StreamServer/SSLServer.h
@@ -15,13 +15,13 @@ public:
 	CSSLServer(CPassiveSock *);
 	~CSSLServer(void);
 	ISocketStream * getSocketStream(void);
-	int Recv(void * const lpBuf, const int Len) override;
-	int Send(const void * const lpBuf, const int Len) override;
+	int Recv(void * const lpBuf, const size_t Len) override;
+	int Send(const void * const lpBuf, const size_t Len) override;
 	int GetLastError(void) override;
 	HRESULT Disconnect(void) override;
 	static PSecurityFunctionTable SSPI(void);
 	// Set up state for this connection
-	HRESULT Initialize(const void * const lpBuf = NULL, const int Len = 0);
+	HRESULT Initialize(const void * const lpBuf = NULL, const size_t Len = 0);
 	std::function<SECURITY_STATUS(PCCERT_CONTEXT & pCertContext, LPCTSTR pszSubjectName)> SelectServerCert;
 	std::function<bool(PCCERT_CONTEXT pCertContext, const bool trusted)> ClientCertAcceptable;
 private:
@@ -31,7 +31,7 @@ private:
 	int m_LastError{};
 	static HRESULT InitializeClass(void);
 	HRESULT Startup(void);
-	int RecvEncrypted(void* const lpBuf, const int Len);
+	int RecvEncrypted(void* const lpBuf, const size_t Len);
 	bool SSPINegotiateLoop(void);
 	static const int MaxMsgSize = 16000; // Arbitrary but less than 16384 limit, including MaxExtraSize
 	static const int MaxExtraSize = 50; // Also arbitrary, current header is 5 bytes, trailer 36


### PR DESCRIPTION
...because the affected functions are e.g. passing sizeof based values, which does not work in 64-Bit build, because 64 bit size does not fit into int.